### PR TITLE
Update sample properties file to use ManualSelectionStrategy

### DIFF
--- a/cantaloupe.properties.sample
+++ b/cantaloupe.properties.sample
@@ -328,7 +328,7 @@ JdbcSource.connection_timeout = 10
 #   dependencies.
 # * If set to `ManualSelectionStrategy`, a processor will be chosen based
 #   on the rest of the keys in this section.
-processor.selection_strategy = AutomaticSelectionStrategy
+processor.selection_strategy = ManualSelectionStrategy
 
 # Built-in processors are `Java2dProcessor`, TurboJpegProcessor`,
 # `KakaduNativeProcessor`, `OpenJpegProcessor`, `GrokProcessor`,`JaiProcessor`,
@@ -340,7 +340,7 @@ processor.ManualSelectionStrategy.avi = FfmpegProcessor
 processor.ManualSelectionStrategy.bmp =
 processor.ManualSelectionStrategy.flv = FfmpegProcessor
 processor.ManualSelectionStrategy.gif =
-processor.ManualSelectionStrategy.jp2 = KakaduNativeProcessor
+processor.ManualSelectionStrategy.jp2 = GrokProcessor
 processor.ManualSelectionStrategy.jpg =
 processor.ManualSelectionStrategy.mov = FfmpegProcessor
 processor.ManualSelectionStrategy.mp4 = FfmpegProcessor

--- a/readme.md
+++ b/readme.md
@@ -8,7 +8,19 @@ There are 3 different commands for running:
 
 ### Default
 
-The default command runs Cantaloupe using [./cantaloupe.properties.sample](cantaloupe.properties.sample).
+The default command runs Cantaloupe using [cantaloupe.properties.sample](cantaloupe.properties.sample).
+
+This sample file is copied from the Cantaloupe repo with the following changes:
+
+```ini
+# Use ManualSelectionStrategy as AutomaticSelectionStrategy will always try and use Kakadu, see Cantaloupe #559
+processor.selection_strategy = ManualSelectionStrategy
+
+# Use GrokProcessor for handling jp2 files
+processor.ManualSelectionStrategy.jp2 = GrokProcessor
+```
+
+> Grok is favoured over OpenJpeg as the latter isn't correctly handling ICC profiles
 
 ### S3 Sourced Properties
 
@@ -21,6 +33,8 @@ Set `KAKADU_LOCATION` env var to a valid S3 location containing Kakadu binaries 
 This will download and extract the Kakadu binaries to appropriate location for cantaloupe.
 
 Also need to set `PROPERTIES_LOCATION` as above as it's expected that config will be loaded from S3.
+
+> Remember to set `AutomaticSelectionStrategy` to use Kakadu, see (default)[#default] above.
 
 #### Kakadu Archive
 


### PR DESCRIPTION
Cantaloupe will always try to use Kakadu if AutomaticSelectionStrategy selected, see https://github.com/cantaloupe-project/cantaloupe/issues/559

Favour Grok over OpenJpeg for ICC handling