### PR TITLE
Set Java memory

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -41,7 +41,6 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Login to GitHub Container Registry
-        if: github.event_name != 'pull_request'
         uses: docker/login-action@v2
         with:
           registry: ghcr.io

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -17,6 +17,16 @@ jobs:
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v2
+
+      - name: Docker meta
+        id: docker-meta
+        uses: docker/metadata-action@v3
+        with:
+          images: ghcr.io/dlcs/cantaloupe
+          tags: |
+            type=ref,event=pr
+            type=raw,value=5.0.5,priority=900,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
+            type=sha,format=long
             
       - name: Cache Docker layers
         uses: actions/cache@v2
@@ -32,7 +42,7 @@ jobs:
 
       - name: Login to GitHub Container Registry
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v1 
+        uses: docker/login-action@v2
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -44,7 +54,5 @@ jobs:
         with:
           context: .
           builder: ${{ steps.buildx.outputs.name }}
-          push: ${{ github.event_name != 'pull_request' }}
-          tags: |
-            ghcr.io/dlcs/cantaloupe:${{ github.sha }}
-            ghcr.io/dlcs/cantaloupe:5.0.5
+          tags: ${{ steps.docker-meta.outputs.tags }}
+          push: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ ENV OPENJPEG_VERSION=2.5.0
 ENV JAVA_HOME=/opt/jdk
 ENV PATH=$PATH:/opt/jdk/bin:/opt/maven/bin
 ENV MAXHEAP=2g
-ENV INITHEAP=2g
+ENV INITHEAP=256m
 ARG DEBIAN_FRONTEND=noninteractive
 
 LABEL maintainer="Donald Gray <donald.gray@digirati.com>"

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,8 @@ ENV CANTALOUPE_VERSION=5.0.5
 ENV OPENJPEG_VERSION=2.5.0
 ENV JAVA_HOME=/opt/jdk
 ENV PATH=$PATH:/opt/jdk/bin:/opt/maven/bin
+ENV MAXHEAP=2g
+ENV INITHEAP=2g
 ARG DEBIAN_FRONTEND=noninteractive
 
 LABEL maintainer="Donald Gray <donald.gray@digirati.com>"
@@ -88,4 +90,4 @@ RUN chmod +x --recursive /opt/app/
 
 EXPOSE 8182
 USER cantaloupeusr
-CMD ["sh", "-c", "java -Dcantaloupe.config=/cantaloupe/cantaloupe.properties.sample -jar /cantaloupe/cantaloupe-$CANTALOUPE_VERSION.jar"]
+CMD ["sh", "-c", "java -Dcantaloupe.config=/cantaloupe/cantaloupe.properties.sample -Xmx$MAXHEAP -Xms$INITHEAP -jar /cantaloupe/cantaloupe-$CANTALOUPE_VERSION.jar"]

--- a/entrypoint/s3-config.sh
+++ b/entrypoint/s3-config.sh
@@ -8,4 +8,4 @@ fi
 echo "Copying properties files from S3 ..."
 aws s3 cp $PROPERTIES_LOCATION /cantaloupe/cantaloupe.properties
 
-java -Dcantaloupe.config=/cantaloupe/cantaloupe.properties -jar /cantaloupe/cantaloupe-$CANTALOUPE_VERSION.jar
+java -Dcantaloupe.config=/cantaloupe/cantaloupe.properties -Xmx$MAXHEAP -Xms$INITHEAP -jar /cantaloupe/cantaloupe-$CANTALOUPE_VERSION.jar

--- a/readme.md
+++ b/readme.md
@@ -14,7 +14,7 @@ This sample file is copied from the Cantaloupe repo with the following changes:
 
 ```ini
 # Use ManualSelectionStrategy as AutomaticSelectionStrategy will always try and use Kakadu, 
-# see Cantaloupe #559
+# see Cantaloupe https://github.com/cantaloupe-project/cantaloupe/issues/559
 processor.selection_strategy = ManualSelectionStrategy
 
 # Use GrokProcessor for handling jp2 files
@@ -120,6 +120,7 @@ docker run --rm -it -p 8182:8182 \
 ```
 
 Alternatively there's a docker compose file to run, copy `.env.dist` -> `.env` and alter as required.
+
 ```bash
 # Run docker-compose
 docker compose up
@@ -144,3 +145,25 @@ Kakadu native processor is supported by providing path to Kakadu (see [above](#k
 ### Dependencies
 
 libjpeg dep is copied from the official [cantaloupe repo](https://github.com/cantaloupe-project/cantaloupe/tree/develop/docker/Linux-JDK11/image_files/libjpeg-turbo/lib64).
+
+## Java Memory 
+
+The initial heap and maximum heap size are defaulted to 2GB in the Dockerfile.
+
+These can be overridden by specifying the following envvars (see https://cantaloupe-project.github.io/manual/5.0/deployment.html#MemoryHeapMemory):
+
+* MAXHEAP - Value for `-Xmx` Java arg.
+* INITHEAP - Value for `-Xms` Java arg.
+
+e.g.
+
+```bash
+docker run --rm -it -p 8182:8182 \
+    -e ENDPOINT_ADMIN_ENABLED=true \
+    -e ENDPOINT_ADMIN_SECRET=admin \
+    -e MAXHEAP=5g \
+    -e INITHEAP=3g \
+    -v path/to/images:/home/cantaloupe/images/ \
+    --name dlcs-cantaloupe \
+    dlcs-cantaloupe:local
+```

--- a/readme.md
+++ b/readme.md
@@ -148,7 +148,7 @@ libjpeg dep is copied from the official [cantaloupe repo](https://github.com/can
 
 ## Java Memory 
 
-The initial heap and maximum heap size are defaulted to 2GB in the Dockerfile.
+The initial heap and maximum heap size are defaulted to initial 256MB/max 2GB in the Dockerfile.
 
 These can be overridden by specifying the following envvars (see https://cantaloupe-project.github.io/manual/5.0/deployment.html#MemoryHeapMemory):
 


### PR DESCRIPTION
Add `MAXHEAP` and `INITHEAP` envvars to allow java heap size to be controlled as default is very conservative.

Modified docker tags:
* `pr-<numb>` pushed when PR opened
* `<sha1>` tag always created
* `5.0.5` tag if pushing to `main`.

For #2 