### PR TITLE
Update to Cantaloupe 5.0.6

### DIFF
--- a/cantaloupe.properties.sample
+++ b/cantaloupe.properties.sample
@@ -494,11 +494,11 @@ cache.server.source = FilesystemCache
 cache.server.source.ttl_seconds = 2592000
 
 # Enables the derivative (processed image) cache.
-cache.server.derivative.enabled = false
+cache.server.derivative.enabled = true
 
 # Available values are `FilesystemCache`, `JdbcCache`, `RedisCache`,
 # `HeapCache`, `S3Cache`, and `AzureStorageCache`.
-cache.server.derivative =
+cache.server.derivative = FilesystemCache
 
 # Amount of time derivative cache content remains valid. Set to blank or 0
 # for forever.

--- a/readme.md
+++ b/readme.md
@@ -131,10 +131,10 @@ docker compose up
 By default it will run with Cantaloupe running the following [processors](https://cantaloupe-project.github.io/manual/5.0/processors.html):
 
 * Ffmpeg
-* Grok
+* Grok (v12.0.3)
 * Jai
 * Java2d
-* OpenJpeg (v2.5.0)
+* OpenJpeg (v2.5.2)
 * PdfBox
 * TurboJpeg
 


### PR DESCRIPTION
Update versions of:
* Cantaloupe to 5.0.6
* OpenJPEG to 2.5.2
* Grok to 12.0.3

Default properties file new has derivative caching enabled using `FilesystemCache`